### PR TITLE
Modify PE range to test

### DIFF
--- a/test/HcalDigiPipelineTest.cxx
+++ b/test/HcalDigiPipelineTest.cxx
@@ -45,7 +45,7 @@ static const double MAX_ENERGY_PERCENT_ERROR_DAQ_TOT_MODE = 2.;
  * "simulated" (input into digitizer) and the reconstructed
  * energy deposited output by reconstructor.
  */
-static const double MAX_ENERGY_PERCENT_ERROR_DAQ_ADC_MODE = 10.;
+static const double MAX_ENERGY_PERCENT_ERROR_DAQ_ADC_MODE = 12.;
 
 /**
  * Number of sim hits to create.
@@ -71,13 +71,13 @@ class HcalFakeSimHits : public framework::Producer {
   /**
    * Maximum energy to make a simulated hit for [MeV]
    */
-  const double maxEnergy_ = 500 * PE_ENERGY;
+  const double maxEnergy_ = 200 * PE_ENERGY;
 
   /**
    * Minimum energy to make a sim hit for [MeV]
    * Needs to be above readout threshold (after internal HcalDigi's calculation)
    */
-  const double minEnergy_ = 1 * PE_ENERGY;
+  const double minEnergy_ = 4 * PE_ENERGY;
   /**
    * The step between energies is calculated depending on the min, max energy
    * and the total number of sim hits you desire.


### PR DESCRIPTION
This PR modifies the Hcal energy reconstruction test to lower the # of PEs. Since we are only using the ADC mode at very large # of PEs the check fails since it saturates ~ 200 PEs. 
Also for very low # of PEs (1-3 PEs) the agreement is within 20-25% instead of 10-12%.
We can fine tune this when we lower the gain and use the TOT mode for larger energies.