### PR TITLE
Allow for single files to be processed in HcalRawDecoder

### DIFF
--- a/python/hgcrocFormat.py
+++ b/python/hgcrocFormat.py
@@ -20,10 +20,11 @@ class HcalRawDecoder(Producer) :
             self.input_names = input_names
         elif input_file is not None :
             self.read_from_file = True
-            self.input_name = input_file
+            self.input_file = input_file
+            self.input_names = ['']
         else :
             raise Exception("Must read from event bus or input file.")
-            
+
         self.input_pass = input_pass # only used when reading from event bus
         self.output_name = output_name
         self.roc_version = roc_version

--- a/src/Hcal/HcalRawDecoder.cxx
+++ b/src/Hcal/HcalRawDecoder.cxx
@@ -535,6 +535,8 @@ class HcalRawDecoder : public framework::Producer {
   }
 
  private:
+  /// input file of encoded data
+  std::string input_file_;
   /// input object of encoded data
   std::vector<std::string> input_names_;
   /// input pass of creating encoded data
@@ -555,6 +557,7 @@ class HcalRawDecoder : public framework::Producer {
 };
 
 void HcalRawDecoder::configure(framework::config::Parameters& ps) {
+  input_file_ = ps.getParameter<std::string>("input_file");
   input_names_ = ps.getParameter<std::vector<std::string>>("input_names",{});
   input_pass_ = ps.getParameter<std::string>("input_pass");
   output_name_ = ps.getParameter<std::string>("output_name");
@@ -562,9 +565,8 @@ void HcalRawDecoder::configure(framework::config::Parameters& ps) {
   translate_eid_ = ps.getParameter<bool>("translate_eid");
   read_from_file_ = ps.getParameter<bool>("read_from_file");
   detector_name_ = ps.getParameter<std::string>("detector_name");
-
   if (read_from_file_) {
-    file_reader_.open(ps.getParameter<std::string>("input_file"));
+    file_reader_.open(input_file_);
   } 
 }
 


### PR DESCRIPTION
This allows for single files to still be processed with the decoder i.e. backwards compatible.