### PR TITLE
separate recon conditions into multiple tables

### DIFF
--- a/include/Hcal/HcalReconConditions.h
+++ b/include/Hcal/HcalReconConditions.h
@@ -16,8 +16,8 @@ namespace hcal {
  */
 class HcalReconConditions : public framework::ConditionsObject {
  public:
-  /// the name of the HcalReconConditions table (must match python registration
-  /// name)
+  /// the name of the HcalReconConditions table 
+  /// (must match python registration name)
   static const std::string CONDITIONS_NAME;
 
   /**
@@ -40,7 +40,7 @@ class HcalReconConditions : public framework::ConditionsObject {
    * @returns the ADC pedestal for that chip in counts
    */
   double adcPedestal(const ldmx::HcalDigiID& id) const {
-    return adc_pedestals_.get(id.raw(), IADC_PEDESTAL);
+    return adc_pedestals_.get(id.raw(), 0);
   }
 
   /**
@@ -54,7 +54,7 @@ class HcalReconConditions : public framework::ConditionsObject {
    * @returns the ADC threshold for that chip in fC/counts
    */
   double adcGain(const ldmx::HcalDigiID& id) const {
-    return adc_gains_.get(id.raw(), IADC_GAIN);
+    return adc_gains_.get(id.raw(), 0);
   }
 
   /**
@@ -64,7 +64,7 @@ class HcalReconConditions : public framework::ConditionsObject {
    * @returns the TOT pedestal for that chip in counts
    */
   double totPedestal(const ldmx::HcalDigiID& id) const {
-    return tot_pedestals_.get(id.raw(), ITOT_PEDESTAL);
+    return tot_pedestals_.get(id.raw(), 0);
   }
 
   /**
@@ -78,7 +78,7 @@ class HcalReconConditions : public framework::ConditionsObject {
    * @returns the TOT gain for that chip in fC/counts
    */
   double totGain(const ldmx::HcalDigiID& id) const {
-    return tot_gains_.get(id.raw(), ITOT_GAIN);
+    return tot_gains_.get(id.raw(), 0);
   }
 
  private:

--- a/include/Hcal/HcalReconConditions.h
+++ b/include/Hcal/HcalReconConditions.h
@@ -8,11 +8,11 @@
 namespace hcal {
 
 /**
- * Class to wrap around an double table of conditions.
+ * Class to wrap around the various recon condition tables
  *
- * This hardcodes the column numbers and checks that
- * the hardcoded numbers match the imported columns
- * during construction.
+ * We expect all of the condition tables to only have two columns
+ * (the DetID and the condition itself) so that the column number
+ * for getting a value from any of them is zero.
  */
 class HcalReconConditions : public framework::ConditionsObject {
  public:

--- a/include/Hcal/HcalReconConditions.h
+++ b/include/Hcal/HcalReconConditions.h
@@ -14,38 +14,24 @@ namespace hcal {
  * the hardcoded numbers match the imported columns
  * during construction.
  */
-class HcalReconConditions {
+class HcalReconConditions : public framework::ConditionsObject {
  public:
   /// the name of the HcalReconConditions table (must match python registration
   /// name)
   static const std::string CONDITIONS_NAME;
-  /// column index for ADC pedestal
-  static const unsigned int IADC_PEDESTAL = 0;
-  /// column index for ADC threshold
-  static const unsigned int IADC_GAIN = 1;
-  /// column index for TOT pedestal
-  static const unsigned int ITOT_PEDESTAL = 2;
-  /// column index for TOT gain
-  static const unsigned int ITOT_GAIN = 3;
-  /// expected order of column names matching the above indices (must match the
-  /// indices above)
-  static const std::vector<std::string> EXPECTED_COLUMNS;
 
   /**
-   * Constructor
+   * Provide the necessary tables to hold in one conditions object
    *
-   * Assign the conditions table to use and (if validate is true),
-   * check if the hard-coded column indices correctly match
-   * the table that is passed.
-   *
-   * @raises Exception if any of the column names from the passed table
-   * do not match the hardcoded indices.
-   *
-   * @param[in] table double table of reconstruction conditions
-   * @param[in] validate true if you want to check the columns
+   * @param[in] adc_ped double table of ADC pedestals
+   * @param[in] adc_gain double table of ADC gains
+   * @param[in] tot_ped double table of TOT pedestals
+   * @param[in] tot_gain double table of TOT gains
    */
-  HcalReconConditions(const conditions::DoubleTableCondition& table,
-                      bool validate = true);
+  HcalReconConditions(const conditions::DoubleTableCondition& adc_ped, 
+      const conditions::DoubleTableCondition& adc_gain,
+      const conditions::DoubleTableCondition& tot_ped,
+      const conditions::DoubleTableCondition& tot_gain);
 
   /**
    * get the ADC pedestal
@@ -54,7 +40,7 @@ class HcalReconConditions {
    * @returns the ADC pedestal for that chip in counts
    */
   double adcPedestal(const ldmx::HcalDigiID& id) const {
-    return the_table_.get(id.raw(), IADC_PEDESTAL);
+    return adc_pedestals_.get(id.raw(), IADC_PEDESTAL);
   }
 
   /**
@@ -68,7 +54,7 @@ class HcalReconConditions {
    * @returns the ADC threshold for that chip in fC/counts
    */
   double adcGain(const ldmx::HcalDigiID& id) const {
-    return the_table_.get(id.raw(), IADC_GAIN);
+    return adc_gains_.get(id.raw(), IADC_GAIN);
   }
 
   /**
@@ -78,7 +64,7 @@ class HcalReconConditions {
    * @returns the TOT pedestal for that chip in counts
    */
   double totPedestal(const ldmx::HcalDigiID& id) const {
-    return the_table_.get(id.raw(), ITOT_PEDESTAL);
+    return tot_pedestals_.get(id.raw(), ITOT_PEDESTAL);
   }
 
   /**
@@ -92,12 +78,18 @@ class HcalReconConditions {
    * @returns the TOT gain for that chip in fC/counts
    */
   double totGain(const ldmx::HcalDigiID& id) const {
-    return the_table_.get(id.raw(), ITOT_GAIN);
+    return tot_gains_.get(id.raw(), ITOT_GAIN);
   }
 
  private:
-  /// reference to the table of conditions storing the chip conditions
-  const conditions::DoubleTableCondition& the_table_;
+  /// reference to the table of conditions storing the adc pedestals
+  const conditions::DoubleTableCondition& adc_pedestals_;
+  /// reference to the table of conditions storing the adc gains
+  const conditions::DoubleTableCondition& adc_gains_;
+  /// reference to the table of conditions storing the tot pedestals
+  const conditions::DoubleTableCondition& tot_pedestals_;
+  /// reference to the table of conditions storing the tot gains
+  const conditions::DoubleTableCondition& tot_gains_;
 };  // HcalReconConditions
 
 }  // namespace hcal

--- a/python/conditions.py
+++ b/python/conditions.py
@@ -25,6 +25,11 @@ class HcalReconConditionsProvider(ldmxcfg.ConditionsObjectProvider) :
         provider for the HCal TOT pedestals
     tot_gain : framework::ConditionsObjectProvider
         provider for the HCal TOT gains
+
+    Examples
+    --------
+    The hcal_hardcoded_conditions.py file provides a working example where each condition
+    wrapped here are constant for all runs and all channels.
     """
 
     def __init__(self,adc_ped,adc_gain,tot_ped,tot_gain) :

--- a/python/conditions.py
+++ b/python/conditions.py
@@ -1,0 +1,39 @@
+"""HCal conditions configuration classes
+
+NOTE: This module is NOT a full set of conditions,
+it is just here to share the configuration classes helpful
+for conditions between the multiple condition sets
+"""
+
+
+from LDMX.Framework import ldmxcfg
+
+class HcalReconConditionsProvider(ldmxcfg.ConditionsObjectProvider) :
+    """The HcalReconConditions object packages the reconstructing conditions tables together
+    
+    This makes the processor using the recon conditions less dependent on the underlying structure,
+    and (for example) a user can have very specific ADC pedestals provided by a per-channel table
+    while keeping the TOT pedestal as an estimated constant.
+
+    Parameters
+    ----------
+    adc_ped : framework::ConditionsObjectProvider
+        provider for the HCal ADC pedestals
+    adc_gain : framework::ConditionsObjectProvider
+        provider for the HCal ADC gains
+    tot_ped : framework::ConditionsObjectProvider
+        provider for the HCal TOT pedestals
+    tot_gain : framework::ConditionsObjectProvider
+        provider for the HCal TOT gains
+    """
+
+    def __init__(self,adc_ped,adc_gain,tot_ped,tot_gain) :
+        super().__init__("HcalReconConditions","hcal::HcalReconConditionsProvider","Hcal")
+
+        # our COP only needs the object names but providing the full parent COPs
+        #   ensures that they exist
+        self.adc_ped = adc_ped.objectName
+        self.adc_gain = adc_gain.objectName
+        self.tot_ped = tot_ped.objectName
+        self.tot_gain = tot_gain.objectName
+

--- a/python/hcal_hardcoded_conditions.py
+++ b/python/hcal_hardcoded_conditions.py
@@ -17,15 +17,40 @@ HcalTrigPrimConditionsHardcode.validForAllRows([ 1 , # ADC_PEDESTAL -- should ma
                                                  10000,  # TOT_THRESHOLD -- rather large value...
                                                  2.5 ] # TOT_GAIN, ratio of recon TOT gain over recon ADC gain
                                                )
+from LDMX.Framework import ldmxcfg
 
-HcalReconConditionsHardcode=SimpleCSVDoubleTableProvider("HcalReconConditions",["ADC_PEDESTAL","ADC_GAIN","TOT_PEDESTAL","TOT_GAIN"])
+class HcalReconConditionsProvider(ldmxcfg.ConditionsObjectProvider) :
+    def __init__(self,adc_ped,adc_gain,tot_ped,tot_gain) :
+        super().__init__("HcalReconConditions","hcal::HcalReconConditionsProvider","Hcal")
 
-HcalReconConditionsHardcode.validForAllRows([
-    1. , #ADC_PEDESTAL - should match HgcrocEmulator
-    1.2, #ADC_GAIN - 4 ADCS per PE - maxADCRange/readoutPadCapacitance/1024
-    1 , #TOT_PEDESTAL - dummy value since TOT is not implemented
-    2.5, #TOT_GAIN - dummy value - conversion to estimated charge deposited in TOT mode
-    ])
+        def extract_obj_name(co) :
+            """If it is a COP, then get the obj name, otherwise return itself"""
+
+            if isinstance(co,ldmxcfg.ConditionsObjectProvider) :
+                return co.objectName
+            else :
+                return co
+
+        self.adc_ped = extract_obj_name(adc_ped)
+        self.adc_gain = extract_obj_name(adc_gain)
+        self.tot_ped = extract_obj_name(tot_ped)
+        self.tot_gain = extract_obj_name(tot_gain)
+
+
+adc_pedestal = SimpleCSVDoubleTableProvider("hcal_adc_pedestal",["pedestal"])
+adc_pedestal.validForAllRows([1.]) # should match HgcrocEmulator
+
+adc_gain = SimpleCSVDoubleTableProvider("hcal_adc_gain",["gain"])
+adc_gain.validForAllRows([1.2]) # 4 ADCs per PE - maxADCRange/readoutPadCapacitance/1024
+
+tot_pedestal = SimpleCSVDoubleTableProvider("hcal_tot_pedestal",["pedestal"])
+tot_pedestal.validForAllRows([1.]) # dummy value since TOT is not implemented
+
+tot_gain = SimpleCSVDoubleTableProvider("hcal_tot_gain",["gain"])
+tot_gain.validForAllRows([2.5]) # dummy value - conversion to estimated charge deposited in TOT mode
+
+# wrap our tables in the parent object that is used by the processors
+HcalReconConditionsProvider(adc_pedestal, adc_gain, tot_pedestal, tot_gain)
 
 HcalHgcrocConditionsHardcode=SimpleCSVDoubleTableProvider("HcalHgcrocConditions", [
             "PEDESTAL",

--- a/python/hcal_hardcoded_conditions.py
+++ b/python/hcal_hardcoded_conditions.py
@@ -17,25 +17,6 @@ HcalTrigPrimConditionsHardcode.validForAllRows([ 1 , # ADC_PEDESTAL -- should ma
                                                  10000,  # TOT_THRESHOLD -- rather large value...
                                                  2.5 ] # TOT_GAIN, ratio of recon TOT gain over recon ADC gain
                                                )
-from LDMX.Framework import ldmxcfg
-
-class HcalReconConditionsProvider(ldmxcfg.ConditionsObjectProvider) :
-    def __init__(self,adc_ped,adc_gain,tot_ped,tot_gain) :
-        super().__init__("HcalReconConditions","hcal::HcalReconConditionsProvider","Hcal")
-
-        def extract_obj_name(co) :
-            """If it is a COP, then get the obj name, otherwise return itself"""
-
-            if isinstance(co,ldmxcfg.ConditionsObjectProvider) :
-                return co.objectName
-            else :
-                return co
-
-        self.adc_ped = extract_obj_name(adc_ped)
-        self.adc_gain = extract_obj_name(adc_gain)
-        self.tot_ped = extract_obj_name(tot_ped)
-        self.tot_gain = extract_obj_name(tot_gain)
-
 
 adc_pedestal = SimpleCSVDoubleTableProvider("hcal_adc_pedestal",["pedestal"])
 adc_pedestal.validForAllRows([1.]) # should match HgcrocEmulator
@@ -50,6 +31,7 @@ tot_gain = SimpleCSVDoubleTableProvider("hcal_tot_gain",["gain"])
 tot_gain.validForAllRows([2.5]) # dummy value - conversion to estimated charge deposited in TOT mode
 
 # wrap our tables in the parent object that is used by the processors
+from .conditions import HcalReconConditionsProvider
 HcalReconConditionsProvider(adc_pedestal, adc_gain, tot_pedestal, tot_gain)
 
 HcalHgcrocConditionsHardcode=SimpleCSVDoubleTableProvider("HcalHgcrocConditions", [

--- a/src/Hcal/HcalRecProducer.cxx
+++ b/src/Hcal/HcalRecProducer.cxx
@@ -114,9 +114,7 @@ void HcalRecProducer::produce(framework::Event& event) {
       ldmx::HcalGeometry::CONDITIONS_OBJECT_NAME);
 
   // get the reconstruction parameters
-  HcalReconConditions the_conditions(
-      getCondition<conditions::DoubleTableCondition>(
-          HcalReconConditions::CONDITIONS_NAME));
+  const auto& the_conditions{getCondition<HcalReconConditions>(HcalReconConditions::CONDITIONS_NAME)};
 
   std::vector<ldmx::HcalHit> hcalRecHits;
   auto hcalDigis =

--- a/src/Hcal/HcalReconConditions.cxx
+++ b/src/Hcal/HcalReconConditions.cxx
@@ -4,34 +4,43 @@ namespace hcal {
 
 const std::string HcalReconConditions::CONDITIONS_NAME = "HcalReconConditions";
 
-/**
- * The order of these column names needs to
- * match the indices listed in the header.
- */
-const std::vector<std::string> HcalReconConditions::EXPECTED_COLUMNS = {
-    "ADC_PEDESTAL", "ADC_GAIN", "TOT_PEDESTAL", "TOT_GAIN"};
-
-HcalReconConditions::HcalReconConditions(
-    const conditions::DoubleTableCondition& table, bool validate)
-    : the_table_{table} {
-  // leave early if we don't want to validate
-  if (!validate) return;
-
-  if (the_table_.getColumnCount() != EXPECTED_COLUMNS.size()) {
-    EXCEPTION_RAISE(
-        "ConditionsException",
-        "Inconsistent condition for HcalReconConditions :" + table.getName());
-  }
-
-  // not using fancy C++17 to shorten this because we want the error to
-  // tell us where the failure is
-  for (size_t i = 0; i < EXPECTED_COLUMNS.size(); i++) {
-    if (the_table_.getColumnNames().at(i) != EXPECTED_COLUMNS.at(i)) {
-      EXCEPTION_RAISE("ConditionsException",
-                      "Expected column '" + EXPECTED_COLUMNS.at(i) +
-                          "', got '" + the_table_.getColumnNames().at(i) + "'");
-    }  // does name match?
-  }    // loop through columns
+HcalReconConditions(const conditions::DoubleTableCondition& adc_ped, 
+    const conditions::DoubleTableCondition& adc_gain,
+    const conditions::DoubleTableCondition& tot_ped,
+    const conditions::DoubleTableCondition& tot_gain)
+  : framework::ConditionsObject(CONDITIONS_NAME),
+    adc_pedestals_{adc_ped}, adc_gains_{adc_gain},
+    tot_pedestals_{tot_ped}, tot_gains_{tot_gain} {}
 }
+
+class HcalReconConditionsProvider : public framework::ConditionsObjectProvider {
+  std::map<std::string,std::unique_ptr<conditions::DoubleTableCondition*>>
+    recon_conditions_;
+ public:
+  HcalReconConditionsProvider(const std::string& name, const std::string& tagname,
+                              const framework::condfig::Parmaeters& parameters,
+                              framework::Process& proc)
+    : ConditionsObjectProvider(HcalReconConditions::CONDITIONS_NAME,
+                               tagname, parameters, proc) {
+      recon_conditions_[parameters.getParameter<std::string>("adc_gain")] = nullptr;
+      recon_conditions_[parameters.getParameter<std::string>("adc_ped")] = nullptr;
+      recon_conditions_[parameters.getParameter<std::string>("tot_gain")] = nullptr;
+      recon_conditions_[parameters.getParameter<std::string>("tot_ped")] = nullptr;
+    }
+
+  /// take no action on release becuase smart pointers
+  virtual void releaseConditionsObject(const framework::ConditionsObject* co) {}
+
+  virtual std::pair<const framework::ConditionsObject*, framework::ConditionsIOV>
+  getCondition(const ldmx::EventHeader& context) {
+    for (auto& [name, table] : recon_conditions_) {
+      if (!table) {
+        // need to get name
+      }
+    }
+
+
+  }
+};
 
 }  // namespace hcal

--- a/src/Hcal/HcalReconConditions.cxx
+++ b/src/Hcal/HcalReconConditions.cxx
@@ -1,46 +1,55 @@
 #include "Hcal/HcalReconConditions.h"
 
+#include "Framework/ConditionsObjectProvider.h"
+
 namespace hcal {
 
 const std::string HcalReconConditions::CONDITIONS_NAME = "HcalReconConditions";
 
-HcalReconConditions(const conditions::DoubleTableCondition& adc_ped, 
+HcalReconConditions::HcalReconConditions(const conditions::DoubleTableCondition& adc_ped, 
     const conditions::DoubleTableCondition& adc_gain,
     const conditions::DoubleTableCondition& tot_ped,
     const conditions::DoubleTableCondition& tot_gain)
-  : framework::ConditionsObject(CONDITIONS_NAME),
+  : framework::ConditionsObject(HcalReconConditions::CONDITIONS_NAME),
     adc_pedestals_{adc_ped}, adc_gains_{adc_gain},
     tot_pedestals_{tot_ped}, tot_gains_{tot_gain} {}
-}
 
 class HcalReconConditionsProvider : public framework::ConditionsObjectProvider {
-  std::map<std::string,std::unique_ptr<conditions::DoubleTableCondition*>>
-    recon_conditions_;
+  std::string adc_gain_, adc_ped_, tot_gain_, tot_ped_;
  public:
   HcalReconConditionsProvider(const std::string& name, const std::string& tagname,
-                              const framework::condfig::Parmaeters& parameters,
+                              const framework::config::Parameters& parameters,
                               framework::Process& proc)
-    : ConditionsObjectProvider(HcalReconConditions::CONDITIONS_NAME,
+    : ConditionsObjectProvider(hcal::HcalReconConditions::CONDITIONS_NAME,
                                tagname, parameters, proc) {
-      recon_conditions_[parameters.getParameter<std::string>("adc_gain")] = nullptr;
-      recon_conditions_[parameters.getParameter<std::string>("adc_ped")] = nullptr;
-      recon_conditions_[parameters.getParameter<std::string>("tot_gain")] = nullptr;
-      recon_conditions_[parameters.getParameter<std::string>("tot_ped")] = nullptr;
+      adc_gain_ = parameters.getParameter<std::string>("adc_gain");
+      adc_ped_ = parameters.getParameter<std::string>("adc_ped");
+      tot_gain_ = parameters.getParameter<std::string>("tot_gain");
+      tot_ped_ = parameters.getParameter<std::string>("tot_ped");
     }
-
-  /// take no action on release becuase smart pointers
-  virtual void releaseConditionsObject(const framework::ConditionsObject* co) {}
 
   virtual std::pair<const framework::ConditionsObject*, framework::ConditionsIOV>
-  getCondition(const ldmx::EventHeader& context) {
-    for (auto& [name, table] : recon_conditions_) {
-      if (!table) {
-        // need to get name
-      }
-    }
+  getCondition(const ldmx::EventHeader& context) final override {
+    auto [ adc_gain_co, adc_gain_iov ] = requestParentCondition(adc_gain_, context);
+    auto [ adc_ped_co , adc_ped_iov  ] = requestParentCondition(adc_ped_ , context);
+    auto [ tot_gain_co, tot_gain_iov ] = requestParentCondition(tot_gain_, context);
+    auto [ tot_ped_co , tot_ped_iov  ] = requestParentCondition(tot_ped_ , context);
+    
+    // deduce "minimum" IOV
+    auto min_iov = adc_ped_iov;
+    
+    // wrap
+    framework::ConditionsObject* co = new hcal::HcalReconConditions(
+        dynamic_cast<const conditions::DoubleTableCondition&>(*adc_ped_co),
+        dynamic_cast<const conditions::DoubleTableCondition&>(*adc_gain_co),
+        dynamic_cast<const conditions::DoubleTableCondition&>(*tot_ped_co),
+        dynamic_cast<const conditions::DoubleTableCondition&>(*tot_gain_co)
+        );
 
-
+    return { co , std::move(min_iov) };
   }
 };
 
 }  // namespace hcal
+
+DECLARE_CONDITIONS_PROVIDER_NS(hcal, HcalReconConditionsProvider);


### PR DESCRIPTION
This development opens the door to allow us to load pedestals by themselves why leaving the gains at a hard-coded estimate.

One thing I noticed while developing this is that we need some way to check for the "smallest" or "minimum" IOV - I will make a Framework issue corresponding to this to avoid forgetting about this.