### PR TITLE
Use geometry condition for horizontal parity

### DIFF
--- a/src/Hcal/HcalDigiProducer.cxx
+++ b/src/Hcal/HcalDigiProducer.cxx
@@ -140,7 +140,7 @@ void HcalDigiProducer::produce(framework::Event& event) {
        * Define two pulses: with positive and negative ends.
        * For this we need to:
        * (1) Find the position along the bar:
-       *     For back Hcal: x (y) for even (odd) layers.
+       *     For back Hcal: x (y) for horizontal (vertical) layers.
        *     For side Hcal: x (top,bottom) and y (left,right).
        *
        * (2) Define the end of the bar:
@@ -168,7 +168,8 @@ void HcalDigiProducer::produce(framework::Event& event) {
       float distance_close, distance_far;
       int end_close;
       if (section == ldmx::HcalID::HcalSection::BACK) {
-        distance_along_bar = (layer % 2) ? position[0] : position[1];
+        distance_along_bar =
+            hcalGeometry.layerIsHorizontal(layer) ? position[0] : position[1];
         end_close = (distance_along_bar > 0) ? 0 : 1;
         distance_close = half_total_width;
         distance_far = half_total_width;

--- a/src/Hcal/HcalRecProducer.cxx
+++ b/src/Hcal/HcalRecProducer.cxx
@@ -252,7 +252,7 @@ void HcalRecProducer::produce(framework::Event& event) {
       amplT = (amplT_posend / att_posend + amplT_negend / att_negend) / 2;
 
       // set position along the bar
-      if ((id_posend.layer() % 2) == 1) {
+      if (hcalGeometry.layerIsHorizontal(id_posend.layer())) {
         position.SetX(position_bar);
       } else {
         position.SetY(position_bar);


### PR DESCRIPTION
Quick patch to use the HcalGeometry condition in HcalRec/DigiProducers. I've tested firing some protons shifted slightly to the right for both `ldmx-hcal-prototype-v1.0`, `ldmx-hcal-prototype-v2.0`, and `ldmx-det-v13` and they all get the SimHit/RecHit x-position distribution shifted to the right so I'm fairly certain that I haven't mixed up any of the checks :) 

This resolves https://github.com/LDMX-Software/Hcal/issues/47 