### PR TITLE
Mark bad links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,5 @@ setup_library(module Hcal
 setup_python(package_name ${PYTHON_PACKAGE_NAME}/Hcal)
 
 setup_test(dependencies Hcal::Hcal)
+
+setup_data(module Hcal)


### PR DESCRIPTION
This is helpful for removing channels which were read out while the link was in a "bad" state. This implementation doesn't drop the channels but instead adds another event object that can be used to check if a channel is from a "bad" link.

If "bad" state is relatively rare for well aligned links, then we could probably start just dropping those channels.

**Note** Draft PR since this depends on some changes in PR #45 and I will just rebase after that is merged in.