### PR TITLE
move noise into hgcroc conditions table

### DIFF
--- a/python/digi.py
+++ b/python/digi.py
@@ -91,7 +91,8 @@ class HcalDigiProducer(Producer) :
         self.avgReadoutThreshold = 4. #ADCs - noise config only
         self.avgGain = 1.2 #noise config only
         self.avgPedestal = 1. #noise config only
-        self.avgNoiseRMS = 2. #noise config only
+        # avg noise set to 0.02PE
+        self.avgNoiseRMS = self.hgcroc.calculateVoltageHcal(0.02)/self.avgGain
         
         # input and output collection name parameters
         self.inputCollName = 'HcalSimHits'

--- a/python/digi.py
+++ b/python/digi.py
@@ -46,9 +46,6 @@ class HcalHgcrocEmulator(HgcrocEmulator) :
         self.timeDnSlope = 45.037
         self.timePeak    = 12.698 # the time such that with [parameter 4]=0, the pulse peaks at t=0
 
-        # noise (0.02PE)
-        self.noiseRMS = self.calculateVoltageHcal(0.02) # mV
-
     def calculateVoltageHcal(self, PE) :
         """Calculate the voltage signal [mV] of the input number of photo-electrons (PEs)
         Assuming that 1 PE ~ 5mV
@@ -94,6 +91,7 @@ class HcalDigiProducer(Producer) :
         self.avgReadoutThreshold = 4. #ADCs - noise config only
         self.avgGain = 1.2 #noise config only
         self.avgPedestal = 1. #noise config only
+        self.avgNoiseRMS = 2. #noise config only
         
         # input and output collection name parameters
         self.inputCollName = 'HcalSimHits'

--- a/python/hcal_hardcoded_conditions.py
+++ b/python/hcal_hardcoded_conditions.py
@@ -53,7 +53,7 @@ HcalHgcrocConditionsHardcode=SimpleCSVDoubleTableProvider("HcalHgcrocConditions"
 
 HcalHgcrocConditionsHardcode.validForAllRows([
     1. , #PEDESTAL 
-    2.0, #NOISE
+    0.02*5/1.2, #NOISE - 0.02 PE with 1 PE ~ 5mV and gain = 1.2
     12.5, #MEAS_TIME - ns - clock_cycle/2 - defines the point in the BX where an in-time (time=0 in times vector) hit would arrive
     20., #PAD_CAPACITANCE - pF
     200., #TOT_MAX - ns - maximum time chip would be in TOT mode

--- a/python/hcal_hardcoded_conditions.py
+++ b/python/hcal_hardcoded_conditions.py
@@ -40,6 +40,7 @@ HcalReconConditionsProvider(adc_pedestal, adc_gain, tot_calib)
 
 HcalHgcrocConditionsHardcode=SimpleCSVDoubleTableProvider("HcalHgcrocConditions", [
             "PEDESTAL",
+            "NOISE",
             "MEAS_TIME",
             "PAD_CAPACITANCE",
             "TOT_MAX",
@@ -52,6 +53,7 @@ HcalHgcrocConditionsHardcode=SimpleCSVDoubleTableProvider("HcalHgcrocConditions"
 
 HcalHgcrocConditionsHardcode.validForAllRows([
     1. , #PEDESTAL 
+    2.0, #NOISE
     12.5, #MEAS_TIME - ns - clock_cycle/2 - defines the point in the BX where an in-time (time=0 in times vector) hit would arrive
     20., #PAD_CAPACITANCE - pF
     200., #TOT_MAX - ns - maximum time chip would be in TOT mode

--- a/src/Hcal/HcalDigiProducer.cxx
+++ b/src/Hcal/HcalDigiProducer.cxx
@@ -54,8 +54,7 @@ void HcalDigiProducer::configure(framework::config::Parameters& ps) {
   double gain = ps.getParameter<double>("avgGain");
   double pedestal = ps.getParameter<double>("avgPedestal");
   // rms noise in mV
-  noiseGenerator_->setNoise(
-      hgcrocParams.getParameter<double>("noiseRMS"));  // rms noise in mV
+  noiseGenerator_->setNoise(gain*ps.getParameter<double>("avgNoiseRMS"));
   // mean noise amplitude (if using Gaussian Model for the noise) in mV
   noiseGenerator_->setPedestal(gain * pedestal);
   // threshold for readout in mV


### PR DESCRIPTION
use ADC=2.0 as the average noise, this is a conservative default that aligns with noise found in CMS HGCAL tests