### PR TITLE
Framework bump rm event def

### DIFF
--- a/include/Hcal/HcalDoubleEndRecProducer.h
+++ b/include/Hcal/HcalDoubleEndRecProducer.h
@@ -9,6 +9,8 @@
 #include "Framework/EventProcessor.h"
 #include "Hcal/HcalReconConditions.h"
 #include "Recon/Event/HgcrocDigiCollection.h"
+#include "Hcal/Event/HcalHit.h"
+
 namespace hcal {
 
 class HcalDoubleEndRecProducer : public framework::Producer {

--- a/include/Hcal/HcalDoubleEndRecProducer.h
+++ b/include/Hcal/HcalDoubleEndRecProducer.h
@@ -6,7 +6,6 @@
 #include "DetDescr/HcalDigiID.h"
 #include "DetDescr/HcalGeometry.h"
 #include "DetDescr/HcalID.h"
-#include "Framework/EventDef.h"
 #include "Framework/EventProcessor.h"
 #include "Hcal/HcalReconConditions.h"
 #include "Recon/Event/HgcrocDigiCollection.h"

--- a/include/Hcal/HcalRecProducer.h
+++ b/include/Hcal/HcalRecProducer.h
@@ -22,8 +22,8 @@
 #include "DetDescr/HcalDigiID.h"
 #include "DetDescr/HcalGeometry.h"
 #include "DetDescr/HcalID.h"
-#include "Framework/EventDef.h"
 #include "Framework/EventProcessor.h"
+#include "Recon/Event/HgcrocDigiCollection.h"
 
 //---------//
 //  ROOT   //

--- a/include/Hcal/HcalSingleEndRecProducer.h
+++ b/include/Hcal/HcalSingleEndRecProducer.h
@@ -9,6 +9,8 @@
 #include "Framework/EventProcessor.h"
 #include "Hcal/HcalReconConditions.h"
 #include "Recon/Event/HgcrocDigiCollection.h"
+#include "Hcal/Event/HcalHit.h"
+
 namespace hcal {
 class HcalSingleEndRecProducer : public framework::Producer {
   /// name of pass of digis to use

--- a/include/Hcal/HcalSingleEndRecProducer.h
+++ b/include/Hcal/HcalSingleEndRecProducer.h
@@ -6,7 +6,6 @@
 #include "DetDescr/HcalDigiID.h"
 #include "DetDescr/HcalGeometry.h"
 #include "DetDescr/HcalID.h"
-#include "Framework/EventDef.h"
 #include "Framework/EventProcessor.h"
 #include "Hcal/HcalReconConditions.h"
 #include "Recon/Event/HgcrocDigiCollection.h"

--- a/src/Hcal/HcalRecProducer.cxx
+++ b/src/Hcal/HcalRecProducer.cxx
@@ -8,6 +8,9 @@
 #include "Hcal/HcalRecProducer.h"
 
 #include "Hcal/HcalReconConditions.h"
+#include "Hcal/Event/HcalHit.h"
+#include "Recon/Event/HgcrocDigiCollection.h"
+#include "SimCore/Event/SimCalorimeterHit.h"
 
 namespace hcal {
 


### PR DESCRIPTION
https://github.com/LDMX-Software/ldmx-sw/pull/1251 for context.

Refactoring of the dictionary building infrastructure removed the `EventDef.h` header. This PR just removes that header and includes the specific event objects needed for the processors instead.